### PR TITLE
ISO4217::Currency::UnknownRate instead of Money::UnknownRate

### DIFF
--- a/lib/currencies/exchange_bank.rb
+++ b/lib/currencies/exchange_bank.rb
@@ -1,6 +1,9 @@
 require 'thread'
 
 class ISO4217::Currency
+  class UnknownRate < StandardError
+  end
+
   class ExchangeBank
     def self.instance
       @@singleton
@@ -38,7 +41,7 @@ class ISO4217::Currency
         if from_currency && to_currency && from_currency.exchange_rate && to_currency.exchange_rate && (from_currency.exchange_currency == to_currency.exchange_currency)
           ((cents * from_currency.exchange_rate) / to_currency.exchange_rate).floor
         else
-          raise Money::UnknownRate, "No conversion rate known for '#{from_currency}' -> '#{to_currency}'"
+          raise UnknownRate, "No conversion rate known for '#{from_currency}' -> '#{to_currency}'"
         end
       end
     end

--- a/lib/currencies/extentions.rb
+++ b/lib/currencies/extentions.rb
@@ -1,4 +1,0 @@
-class Money
-  class UnknownRate < StandardError
-  end
-end 

--- a/lib/iso4217.rb
+++ b/lib/iso4217.rb
@@ -3,6 +3,5 @@ $LOAD_PATH << File.expand_path(File.dirname(__FILE__))
 require 'YAML' unless defined?(YAML)
 require 'net/http' unless defined?(Net::HTTP)
 
-require 'currencies/extentions'
 require 'currencies/currency'
 require 'currencies/exchange_bank'

--- a/spec/exchange_bank_spec.rb
+++ b/spec/exchange_bank_spec.rb
@@ -42,8 +42,8 @@ describe ISO4217::Currency::ExchangeBank do
     block.should_not raise_error
   end
   
-  it "raises Money::UnknownRate upon conversion if the conversion rate is unknown" do
+  it "raises ISO4217::Currency::UnknownRate upon conversion if the conversion rate is unknown" do
     block = lambda { @bank.exchange(10, "USD", "BUTTON") }
-    block.should raise_error(Money::UnknownRate)
+    block.should raise_error(ISO4217::Currency::UnknownRate)
   end
 end


### PR DESCRIPTION
To avoid clashing with other class named Money.