### PR TITLE
Update iso4217.yaml

### DIFF
--- a/lib/data/iso4217.yaml
+++ b/lib/data/iso4217.yaml
@@ -31,6 +31,7 @@ ANG:
 AOA:
   code: AOA
   name: Kwanza
+  symbol: Kz
   full_name: "Angolan Kwanza"
 ARS:
   code: ARS


### PR DESCRIPTION
Added missing Kwanza (AOA) currency symbol.

http://en.wikipedia.org/wiki/Angolan_kwanza