### PR TITLE
Update Zambian Kwacha (ZMK to ZMW)

### DIFF
--- a/lib/data/iso4217.yaml
+++ b/lib/data/iso4217.yaml
@@ -929,10 +929,11 @@ ZAR:
   full_name: "South Africa Rand"
   symbol: R
   unicode_hex: 82
-ZMK:
-  code: ZMK
+ZMW:
+  code: ZMW
   name: Kwacha
-  full_name: "Kwacha"
+  full_name: "Zambian Kwacha"
+  symbol: K
 ZWD:
   code: ZWD
   name: "Zimbabwe Dollars"
@@ -941,4 +942,3 @@ ZWD:
   unicode_hex:
     - 90
     - 36
-


### PR DESCRIPTION
Rebased Jan 1, 2013 with new ISO code