### PR TITLE
Update Venezuela Bolivar Fuerte to Bolivar Soberano (iso4217.yaml)

### DIFF
--- a/lib/data/iso4217.yaml
+++ b/lib/data/iso4217.yaml
@@ -890,10 +890,10 @@ UZS:
   unicode_hex:
     - 1083
     - 1074
-VEF:
-  code: VEF
-  name: "Bolivares Fuertes"
-  full_name: "Venezuela Bolivares Fuertes"
+VES:
+  code: VES
+  name: "Bolivar Soberano"
+  full_name: "Venezuela Bolivar Soberano"
   symbol: Bs
   unicode_hex:
     - 1083


### PR DESCRIPTION
New currency in Venezuela (VES):
Details of this new currency code are as follows:
Alpha code: VES
Currency name: Bolivar Soberano
Numeric code: 928
Fractional digit: 2
This new currency code is introduced as legal tender as of
20 August 2018.